### PR TITLE
Enable running only single test class or method

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,28 @@ apply plugin: 'spoon'
 // for debug output
 spoon {
   debug = true
+
+  // To run a single test class
+  className = fully.qualified.TestCase
+
+  // To run a single method in TestCase
+  methodName = testMyApp
+}
+```
+
+You may also setup your project to take parameters for class/method to be run from command line. E.g.:
+
+```
+gradle spoon -PspoonClassName=fully.qualified.TestCase
+```
+
+And project configuration:
+
+```groovy
+spoon {
+  if (project.hasProperty('spoonClassName')) {
+    className = project.spoonClassName  
+  }
 }
 ```
 

--- a/src/main/groovy/com/stanfy/spoon/gradle/SpoonExtension.groovy
+++ b/src/main/groovy/com/stanfy/spoon/gradle/SpoonExtension.groovy
@@ -11,4 +11,9 @@ class SpoonExtension {
   /** Ignore test failures flag. */
   boolean ignoreFailures
 
+  /** Fully qualified name of the test class to be run (e.g. com.example.foo.test.MyTestCase). */
+  String className
+
+  /** Test method to be run. Used when `className` is provided. */
+  String methodName
 }

--- a/src/main/groovy/com/stanfy/spoon/gradle/SpoonPlugin.groovy
+++ b/src/main/groovy/com/stanfy/spoon/gradle/SpoonPlugin.groovy
@@ -47,6 +47,13 @@ class SpoonPlugin implements Plugin<Project> {
         debug = project.spoon.debug
         ignoreFailures = project.spoon.ignoreFailures
 
+        if (project.spoon.className) {
+          className = project.spoon.className
+          if (project.spoon.methodName) {
+            methodName = project.spoon.methodName
+          }          
+        }
+
         dependsOn variant.assemble, variant.testedVariant.assemble
       }
 


### PR DESCRIPTION
To configure, set values for `project.spoon.className` and `project.spoon.methodName`.

To enable setting class/method from command line, project may be configured like this:

``` groovy
spoon {
    if (project.hasProperty('spoonClassName')) {
        className = project.spoonClassName

        if (project.hasProperty('spoonMethodName')) {
            methodName = project.spoonMethodName
        }
    }
}
```

`gradle spoonMyProjectTest -PspoonClassName=com.myproject.test.SomeTest -PspoonMethodName=testHomeScreen`

However, project property names are completely arbitrary. Yu may also use Java `System.properties`, e.g. `-Dspoon.methodName=...`
