### PR TITLE
Use camelCase for generated tasks

### DIFF
--- a/src/main/groovy/com/stanfy/spoon/gradle/SpoonPlugin.groovy
+++ b/src/main/groovy/com/stanfy/spoon/gradle/SpoonPlugin.groovy
@@ -34,7 +34,7 @@ class SpoonPlugin implements Plugin<Project> {
     AppExtension android = project.android
     android.testVariants.all { TestVariant variant ->
 
-      String taskName = "${TASK_PREFIX}${variant.name}"
+      String taskName = "${TASK_PREFIX}${variant.name.capitalize()}"
 
       SpoonRunTask task = project.tasks.create(taskName, SpoonRunTask)
       SpoonExtension config = project.spoon


### PR DESCRIPTION
Tasks generated by the android gradle plugin normally use camel case for naming variants.

example:
gradlew assembleDevDebugTest

currently:
gradlew spoondevDebugTest

with patch:
gradlew spoonDevDebugTest

ps. Thanks for making this available.
