### PR TITLE
Fixing build error when plugin inherited from android used

### DIFF
--- a/src/main/groovy/com/stanfy/spoon/gradle/SpoonPlugin.groovy
+++ b/src/main/groovy/com/stanfy/spoon/gradle/SpoonPlugin.groovy
@@ -20,7 +20,7 @@ class SpoonPlugin implements Plugin<Project> {
   @Override
   void apply(final Project project) {
 
-    if (!project.plugins.hasPlugin(AppPlugin)) {
+    if (!project.plugins.withType(AppPlugin)) {
       throw new IllegalStateException("Android plugin is not found")
     }
 


### PR DESCRIPTION
We are using DexGuard plugin, which replaces android. The check hasPlugin doesn't work in that case, although DexGuard plugin can do all the things that android can.
