### PR TITLE
Replace instrumentTestCompile with androidTestCompile

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For making screenshots add `spoon-client` dependency to your tests compile confi
 ```groovy
 dependencies {
 
-  instrumentTestCompile 'com.squareup.spoon:spoon-client:1.1.0'
+  androidTestCompile 'com.squareup.spoon:spoon-client:1.1.0'
 
 }
 ```


### PR DESCRIPTION
According to http://tools.android.com/tech-docs/new-build-system/migrating_to_09 the instrumentTestCompile has been changed to androidTestCompile starting with gradle plugin 0.9
