### PR TITLE
Android 1.1.x fix

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -5,7 +5,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:1.0.0-rc1'
+    classpath 'com.android.tools.build:gradle:1.1.0-rc1'
     classpath 'com.stanfy.spoon:spoon-gradle-plugin:0.14.2-SNAPSHOT'
   }
 }

--- a/src/main/groovy/com/stanfy/spoon/gradle/SpoonPlugin.groovy
+++ b/src/main/groovy/com/stanfy/spoon/gradle/SpoonPlugin.groovy
@@ -94,7 +94,7 @@ class SpoonPlugin implements Plugin<Project> {
       throw new UnsupportedOperationException("Spoon plugin for gradle currently does not support abi/density splits for test apks")
     }
     SpoonExtension config = project.spoon
-    return testVariant.testedVariant.outputs.collect { def projectOutput ->
+    return testVariant.outputs.collect { def projectOutput ->
       SpoonRunTask task = project.tasks.create("${TASK_PREFIX}${testVariant.name.capitalize()}${suffix}", SpoonRunTask)
       task.configure {
         group = JavaBasePlugin.VERIFICATION_GROUP


### PR DESCRIPTION
Hi,

First thanks for this plugin. This pull request should solve the issue #37 . I didn't find any change regarding the testedVariant property which is null. As a fix I just use the testVariant instead of testedVariant to get 'outputs' directory. It fixes the problem in my current project. I've also updated the example app to the new version of android plugin. Let me know if It's fine for you.