### PR TITLE
Added support to provide device Id on runtime.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ dependencies {
   androidTestCompile 'com.squareup.spoon:spoon-client:1.1.9'
 }
 ```
-
+Device Selection
+-------------
 By default the plugin runs tests on all the connected devices.
 In order to run them on some concrete devices instead, you may specify their serial numbers:
 ```groovy
@@ -59,6 +60,13 @@ spoon {
   devices = ['333236E9AE5800EC']
 }
 ```
+#### &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; OR
+You can specify device Id on runtime too:
+```
+gradle spoon -PdeviceId=333236E9AE5800EC
+```
+(this way you can run tests for different variants **Parallely** on different devices)
+***
 
 It is also allowed to specify specify size of tests that should be run. You may run all the tests
 annotated as `@SmallTest` with the following line:

--- a/src/main/groovy/com/stanfy/spoon/gradle/SpoonRunTask.groovy
+++ b/src/main/groovy/com/stanfy/spoon/gradle/SpoonRunTask.groovy
@@ -149,8 +149,11 @@ class SpoonRunTask extends DefaultTask implements VerificationTask {
       LOG.info("ADB timeout $adbTimeout")
       runBuilder.setAdbTimeout(adbTimeout)
     }  
-        
-    if (allDevices) {
+    if (project.hasProperty("deviceId")) {
+      runBuilder.addDevice(project.deviceId)
+      LOG.info("Using device $project.deviceId")
+    }
+    else if (allDevices) {
       runBuilder.useAllAttachedDevices()
       LOG.info("Using all the attached devices")
     } else {


### PR DESCRIPTION
Added support to provide device Id on runtime. so that user can run test for different variants on different device in Parallel way.
Let me know, if you have any thoughts on this.