### PR TITLE
Update spoon version to fix Android Gradle plugin 1.5.0 compatibility issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
   compile gradleApi()
   compile localGroovy()
 
-  compile 'com.squareup.spoon:spoon-runner:1.2.0'
+  compile 'com.squareup.spoon:spoon-runner:1.2.1'
 
   compile 'com.android.tools.build:gradle:1.3.1'
 


### PR DESCRIPTION
Error before update:
Execution failed for task ':app:spoonDebugAndroidTest'. >
com.android.ddmlib.IDevice.installPackage(Ljava/lang/String...