### PR TITLE
Update to Spoon 1.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Generated reports are available at `build/spoon/${TEST_VARIANT}` folder.
 For making screenshots add `spoon-client` dependency to your tests compile configuration:
 ```groovy
 dependencies {
-  androidTestCompile 'com.squareup.spoon:spoon-client:1.3.1'
+  androidTestCompile 'com.squareup.spoon:spoon-client:1.3.2'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
   compile gradleApi()
   compile localGroovy()
 
-  compile 'com.squareup.spoon:spoon-runner:1.3.1'
+  compile 'com.squareup.spoon:spoon-runner:1.3.2'
 
   compile 'com.android.tools.build:gradle:1.5.0'
 

--- a/example/app/build.gradle
+++ b/example/app/build.gradle
@@ -62,7 +62,7 @@ repositories {
 }
 
 dependencies {
-  androidTestCompile "com.squareup.spoon:spoon-client:1.3.1"
+  androidTestCompile "com.squareup.spoon:spoon-client:1.3.2"
 }
 
 // for integration test of this plugin


### PR DESCRIPTION
Fixes the default adbTimeout issue that still happens in Spoon 1.3.1.