### PR TITLE
Add sdcard to emulator to fix Travis spoon failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ install:
 
 before_script:
   - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
-  - emulator -avd test -no-skin -no-audio -no-window &
+  - mksdcard -l e 512M sdcard.img
+  - emulator -avd test -no-skin -no-audio -no-window -sdcard sdcard.img &
   - android-wait-for-emulator
   - adb shell input keyevent 82
 


### PR DESCRIPTION
to avoid java.lang.IllegalAccessException: Unable to create output dir: /storage/sdcard/app_spoon-screenshots.
Please do check before merging, I did not test this config on Travis.