### PR TITLE
code coverage option for spoon-gradle-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,15 @@ spoon {
 }
 ```
 
+Code Coverage
+--------------------------------
+You can configure spoon to calculate code coverage by using `codeCoverage` property on `spoon` extension:
+```groovy
+spoon {
+  codeCoverage = true
+}
+```
+
 Known issues
 ------------
 If you have troubles with running Android Lint after this plugin is applied, try the following workaround

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
   compile gradleApi()
   compile localGroovy()
 
-  compile 'com.squareup.spoon:spoon-runner:1.3.2'
+  compile 'com.squareup.spoon:spoon-runner:1.5.0'
 
   compile 'com.android.tools.build:gradle:1.5.0'
 

--- a/src/main/groovy/com/stanfy/spoon/gradle/SpoonExtension.groovy
+++ b/src/main/groovy/com/stanfy/spoon/gradle/SpoonExtension.groovy
@@ -42,4 +42,6 @@ class SpoonExtension {
   /** The shardIndex option to specify which shard to run. */
   int shardIndex
 
+  /** The codeCoverage option to calculate code coverage. */
+  boolean codeCoverage
 }

--- a/src/main/groovy/com/stanfy/spoon/gradle/SpoonPlugin.groovy
+++ b/src/main/groovy/com/stanfy/spoon/gradle/SpoonPlugin.groovy
@@ -121,6 +121,7 @@ class SpoonPlugin implements Plugin<Project> {
         allDevices = !config.devices
         noAnimations = config.noAnimations
         failIfNoDeviceConnected = config.failIfNoDeviceConnected
+        codeCoverage = config.codeCoverage
         if (config.adbTimeout != -1) {
           // Timeout is defined in seconds in the config.
           adbTimeout = config.adbTimeout * 1000

--- a/src/main/groovy/com/stanfy/spoon/gradle/SpoonRunTask.groovy
+++ b/src/main/groovy/com/stanfy/spoon/gradle/SpoonRunTask.groovy
@@ -86,6 +86,9 @@ class SpoonRunTask extends DefaultTask implements VerificationTask {
   /** The shardIndex option to specify which shard to run. */
   int shardIndex
 
+  /** The codeCoverage option to calculate code coverage. */
+  boolean codeCoverage;
+
   @TaskAction
   void runSpoon() {
     LOG.info("Run instrumentation tests $instrumentationApk for app $applicationApk")
@@ -126,6 +129,7 @@ class SpoonRunTask extends DefaultTask implements VerificationTask {
         .setAndroidSdk(project.android.sdkDirectory)
         .setClasspath(cp)
         .setNoAnimations(noAnimations)
+        .setCodeCoverage(codeCoverage)
 
     def instrumentationArgs = this.instrumentationArgs
     if (instrumentationArgs == null) {


### PR DESCRIPTION
this option will enable the user to use coverage property as `codeCoverage = true` in order to calculate code coverage. Once tests are finished, it will automatically pull the `coverage.ec` file from device to `{spoon output directory}/coverage` directory.

It will help us to resolve [this issue](https://github.com/stanfy/spoon-gradle-plugin/issues/79).
