### PR TITLE
Sharding support for spoon-gradle-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ spoon {
   shardIndex = 0
 }
 ```
+If you are specifying sharding for multiple devices, you may use spoon's built in auto-sharding by specifying:
+```groovy
+spoon {
+  shard = true
+}
+```
+This will automatically shard across all specified serials, and merge the results.
 
 Custom instrumentation arguments
 --------------------------------

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
   compile gradleApi()
   compile localGroovy()
 
-  compile 'com.squareup.spoon:spoon-runner:1.5.0'
+  compile 'com.squareup.spoon:spoon-runner:1.5.3'
 
   compile 'com.android.tools.build:gradle:1.5.0'
 

--- a/src/main/groovy/com/stanfy/spoon/gradle/SpoonExtension.groovy
+++ b/src/main/groovy/com/stanfy/spoon/gradle/SpoonExtension.groovy
@@ -44,4 +44,7 @@ class SpoonExtension {
 
   /** The codeCoverage option to calculate code coverage. */
   boolean codeCoverage
+
+  /** The shard option to specify whether to shard tests or not. */
+  boolean shard
 }

--- a/src/main/groovy/com/stanfy/spoon/gradle/SpoonPlugin.groovy
+++ b/src/main/groovy/com/stanfy/spoon/gradle/SpoonPlugin.groovy
@@ -122,6 +122,7 @@ class SpoonPlugin implements Plugin<Project> {
         noAnimations = config.noAnimations
         failIfNoDeviceConnected = config.failIfNoDeviceConnected
         codeCoverage = config.codeCoverage
+        shard = config.shard
         if (config.adbTimeout != -1) {
           // Timeout is defined in seconds in the config.
           adbTimeout = config.adbTimeout * 1000

--- a/src/main/groovy/com/stanfy/spoon/gradle/SpoonRunTask.groovy
+++ b/src/main/groovy/com/stanfy/spoon/gradle/SpoonRunTask.groovy
@@ -89,6 +89,9 @@ class SpoonRunTask extends DefaultTask implements VerificationTask {
   /** The codeCoverage option to calculate code coverage. */
   boolean codeCoverage;
 
+  /** The shard option to specify whether to shard tests or not. */
+  boolean shard;
+
   @TaskAction
   void runSpoon() {
     LOG.info("Run instrumentation tests $instrumentationApk for app $applicationApk")
@@ -130,6 +133,7 @@ class SpoonRunTask extends DefaultTask implements VerificationTask {
         .setClasspath(cp)
         .setNoAnimations(noAnimations)
         .setCodeCoverage(codeCoverage)
+        .setShard(shard)
 
     def instrumentationArgs = this.instrumentationArgs
     if (instrumentationArgs == null) {


### PR DESCRIPTION
adding support to use spoon-runner's inbuilt `shard` option for multiple devices. It will automatically shard across all devices, and merge the results.