### PR TITLE
Merging multiple coverage files into one

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
   compile gradleApi()
   compile localGroovy()
 
-  compile 'com.squareup.spoon:spoon-runner:1.5.3'
+  compile 'com.squareup.spoon:spoon-runner:1.5.4'
 
   compile 'com.android.tools.build:gradle:1.5.0'
 


### PR DESCRIPTION
Current spoon runner version has the capability to merge multiple coverage files generated from multiple devices into one file `merged-coverage.ec`. 
This functionality is useful when a user has provided the option like `shard = true` to divide the whole test suite to run on multiple devices and getting different coverage files. Now spoon plugin is able to merge all these coverage files and save the merged file as `{spoon output directory}/coverage/merged-coverage.ec`.
