### PR TITLE
Added support for spoon --sequential flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ spoon {
 
   // To run a single method in TestCase
   methodName = 'testMyApp'
+
+  // To execute the tests device by device */
+  sequential = true
 }
 ```
 

--- a/src/main/groovy/com/stanfy/spoon/gradle/SpoonExtension.groovy
+++ b/src/main/groovy/com/stanfy/spoon/gradle/SpoonExtension.groovy
@@ -47,4 +47,7 @@ class SpoonExtension {
 
   /** The shard option to specify whether to shard tests or not. */
   boolean shard
+
+  /** Execute the tests device by device */
+  boolean sequential
 }

--- a/src/main/groovy/com/stanfy/spoon/gradle/SpoonPlugin.groovy
+++ b/src/main/groovy/com/stanfy/spoon/gradle/SpoonPlugin.groovy
@@ -119,6 +119,7 @@ class SpoonPlugin implements Plugin<Project> {
         ignoreFailures = config.ignoreFailures
         devices = config.devices
         allDevices = !config.devices
+        sequential = config.sequential
         noAnimations = config.noAnimations
         failIfNoDeviceConnected = config.failIfNoDeviceConnected
         codeCoverage = config.codeCoverage

--- a/src/main/groovy/com/stanfy/spoon/gradle/SpoonRunTask.groovy
+++ b/src/main/groovy/com/stanfy/spoon/gradle/SpoonRunTask.groovy
@@ -92,6 +92,9 @@ class SpoonRunTask extends DefaultTask implements VerificationTask {
   /** The shard option to specify whether to shard tests or not. */
   boolean shard;
 
+  /** Execute the tests device by device */
+  boolean sequential
+
   @TaskAction
   void runSpoon() {
     LOG.info("Run instrumentation tests $instrumentationApk for app $applicationApk")
@@ -134,6 +137,7 @@ class SpoonRunTask extends DefaultTask implements VerificationTask {
         .setNoAnimations(noAnimations)
         .setCodeCoverage(codeCoverage)
         .setShard(shard)
+        .setSequential(sequential)
 
     def instrumentationArgs = this.instrumentationArgs
     if (instrumentationArgs == null) {


### PR DESCRIPTION
When true devices are queued to run tests. Handy when ui test depends on some external state, for example backend server. This option was supported by spoon, fix just enables it in gradle configuration.