### PR TITLE
Device code coverage fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ spoon {
   codeCoverage = true
 }
 ```
+This option requires your app to have the `WRITE_EXTERNAL_STORAGE` permission.
 
 Known issues
 ------------

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
   compile gradleApi()
   compile localGroovy()
 
-  compile 'com.squareup.spoon:spoon-runner:1.5.4'
+  compile 'com.squareup.spoon:spoon-runner:1.5.5'
 
   compile 'com.android.tools.build:gradle:1.5.0'
 


### PR DESCRIPTION
with this change, spoon plugin will be able to pull and merge the coverage file from physical devices as well, since it's being generated into the external storage now. 
`tested on Lenovo A7000 (API 23)` and `Genymotion instance (API 21 Google Nexus)`