### PR TITLE
Add ability to exclude devices for test runs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
   compile gradleApi()
   compile localGroovy()
 
-  compile 'com.squareup.spoon:spoon-runner:1.6.2'
+  compile 'com.squareup.spoon:spoon-runner:1.6.4'
 
   compile 'com.android.tools.build:gradle:1.5.0'
 

--- a/src/main/groovy/com/stanfy/spoon/gradle/SpoonExtension.groovy
+++ b/src/main/groovy/com/stanfy/spoon/gradle/SpoonExtension.groovy
@@ -25,7 +25,10 @@ class SpoonExtension {
 
   /** Devices to run the tests on (specified with serial numbers). */
   Set<String> devices
-  
+
+  /** Devices to skip running the tests on (specified with serial numbers). */
+  Set<String> skipDevices
+
   /** Whether or not animations are enabled, useful for slow machines or projects with many screenshots. */
   boolean noAnimations
 

--- a/src/main/groovy/com/stanfy/spoon/gradle/SpoonPlugin.groovy
+++ b/src/main/groovy/com/stanfy/spoon/gradle/SpoonPlugin.groovy
@@ -118,6 +118,7 @@ class SpoonPlugin implements Plugin<Project> {
         debug = config.debug
         ignoreFailures = config.ignoreFailures
         devices = config.devices
+        skipDevices = config.skipDevices
         allDevices = !config.devices
         sequential = config.sequential
         noAnimations = config.noAnimations

--- a/src/main/groovy/com/stanfy/spoon/gradle/SpoonRunTask.groovy
+++ b/src/main/groovy/com/stanfy/spoon/gradle/SpoonRunTask.groovy
@@ -80,6 +80,9 @@ class SpoonRunTask extends DefaultTask implements VerificationTask {
   /** Devices to run on. */
   Set<String> devices
 
+  /** Devices to skip running on. */
+  Set<String> skipDevices
+
   /** The number of separate shards to create. */
   int numShards
 
@@ -163,8 +166,13 @@ class SpoonRunTask extends DefaultTask implements VerificationTask {
     if (adbTimeout != -1) {
       LOG.info("ADB timeout $adbTimeout")
       runBuilder.setAdbTimeout(adbTimeout)
-    }  
-        
+    }
+
+    if (skipDevices != null && !skipDevices.isEmpty()) {
+      skipDevices.each {
+        runBuilder.skipDevice(it);
+      }
+    }
     if (allDevices) {
       runBuilder.useAllAttachedDevices()
       LOG.info("Using all the attached devices")
@@ -175,7 +183,9 @@ class SpoonRunTask extends DefaultTask implements VerificationTask {
       devices.each {
         runBuilder.addDevice(it)
       }
+
       LOG.info("Using devices $devices")
+      LOG.info("Skipping following devices: $skipDevices")
     }
 
     boolean success = runBuilder.build().run()


### PR DESCRIPTION
Usefull for excluding specific set of devices during test runs.
Example End 2 End tests that use dedicated devices for tests in larger test automation setups.

Bump spoon runner to 1.6.4 with:
Fix: allow double-marking failure/error
New: skipDevice flag to allow excluding certain devices