### PR TITLE
Bump spoon runner version to 1.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
   compile gradleApi()
   compile localGroovy()
 
-  compile 'com.squareup.spoon:spoon-runner:1.6.4'
+  compile 'com.squareup.spoon:spoon-runner:1.7.0'
 
   compile 'com.android.tools.build:gradle:1.5.0'
 


### PR DESCRIPTION
Version 1.7.0 (2016-09-12)

Fix: upgraded jacoco to fix code coverage merging
Fix: escape HTML in exception titles
Fix: allow unexpected exception format to continue parsing
Fix: eagerly blow up if view is 0x0
Fix: show install exceptions in the results output
