### PR TITLE
Bumping up spoon-runner version to 1.7.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
   compile gradleApi()
   compile localGroovy()
 
-  compile 'com.squareup.spoon:spoon-runner:1.7.0'
+  compile 'com.squareup.spoon:spoon-runner:1.7.1'
 
   compile 'com.android.tools.build:gradle:1.5.0'
 


### PR DESCRIPTION
this change is required to fix the issue in which spoon-runner was not able to generate the coverage reports when target application is crashed. See [this issue](https://github.com/square/spoon/issues/415) for more details.