### PR TITLE
Running plugin in case of apk splits.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ spoon {
 
   // To grant permissions to Android M >= devices */
   grantAllPermissions = true
+
+  // Define build variant to be used for testing. Useful when working with apk splits  */
+  testVariant = "x86Screenshot"
 }
 ```
 

--- a/src/main/groovy/com/stanfy/spoon/gradle/SpoonExtension.groovy
+++ b/src/main/groovy/com/stanfy/spoon/gradle/SpoonExtension.groovy
@@ -56,4 +56,8 @@ class SpoonExtension {
 
   /** Grants all permisions for Android M >= devices */
   boolean grantAllPermissions
+
+  /** Define build variant to be used for testing (ex. testVariant = "x86Screenshot"). Useful when working with apk splits **/
+  String testVariant
+
 }

--- a/src/main/groovy/com/stanfy/spoon/gradle/SpoonPlugin.groovy
+++ b/src/main/groovy/com/stanfy/spoon/gradle/SpoonPlugin.groovy
@@ -94,9 +94,11 @@ class SpoonPlugin implements Plugin<Project> {
       throw new UnsupportedOperationException("Spoon plugin for gradle currently does not support abi/density splits for test apks")
     }
     SpoonExtension config = project.spoon
-    return testVariant.testedVariant.outputs.findAll { def projectOutput ->
-          config.testVariant.isEmpty() || (projectOutput.getName() == config.testVariant)
-        }.collect { def projectOutput ->
+    return testVariant.testedVariant.outputs
+    .findAll { def projectOutput ->
+      config.testVariant == null || config.testVariant.isEmpty() || (projectOutput.getName() == config.testVariant)
+    }
+    .collect { def projectOutput ->
       SpoonRunTask task = project.tasks.create("${TASK_PREFIX}${testVariant.name.capitalize()}${suffix}", SpoonRunTask)
       task.configure {
         group = JavaBasePlugin.VERIFICATION_GROUP

--- a/src/main/groovy/com/stanfy/spoon/gradle/SpoonPlugin.groovy
+++ b/src/main/groovy/com/stanfy/spoon/gradle/SpoonPlugin.groovy
@@ -94,7 +94,9 @@ class SpoonPlugin implements Plugin<Project> {
       throw new UnsupportedOperationException("Spoon plugin for gradle currently does not support abi/density splits for test apks")
     }
     SpoonExtension config = project.spoon
-    return testVariant.testedVariant.outputs.collect { def projectOutput ->
+    return testVariant.testedVariant.outputs.findAll { def projectOutput ->
+          config.testVariant.isEmpty() || (projectOutput.getName() == config.testVariant)
+        }.collect { def projectOutput ->
       SpoonRunTask task = project.tasks.create("${TASK_PREFIX}${testVariant.name.capitalize()}${suffix}", SpoonRunTask)
       task.configure {
         group = JavaBasePlugin.VERIFICATION_GROUP


### PR DESCRIPTION
I had a problem to run plugin when using abi splits.
Added a parameter that when defined filters list of all variants to provided name. Tested locally only and seems to work correctly.